### PR TITLE
feat: generate and use state on auth

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,6 +17,7 @@
   ],
   "rules": {
     "@typescript-eslint/no-unused-vars": 2,
+    "complexity": ["error", 10],
     "no-console": "off",
     "no-else-return": "off",
     "no-unused-expressions": "off",

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ to bridge that gap and also provide a convenient interface to use.
 
 ## What is still missing?
 
-- [ ] utilise the STATE parameter to prevent CSRF
 - [ ] failed events should remove the user from the session automatically
 - [ ] see if we can handle the callback while maintaining the session from before the login
 - [ ] opt out of the session handling

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.0-dev",
       "license": "GPL-3.0",
       "dependencies": {
-        "jose": "^4.13.0"
+        "jose": "^4.13.0",
+        "uuid": "^9.0.0"
       },
       "devDependencies": {
         "@commitlint/cli": "17.4.4",
@@ -23,6 +24,7 @@
         "@semantic-release/release-notes-generator": "^10.0.3",
         "@types/is-ci": "^3.0.0",
         "@types/node": "^18.14.2",
+        "@types/uuid": "^9.0.1",
         "@typescript-eslint/eslint-plugin": "^5.54.0",
         "@typescript-eslint/parser": "^5.54.0",
         "@vitest/coverage-c8": "^0.29.0",
@@ -59,6 +61,15 @@
       "dependencies": {
         "@actions/http-client": "^2.0.1",
         "uuid": "^8.3.2"
+      }
+    },
+    "node_modules/@actions/core/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@actions/http-client": {
@@ -1947,6 +1958,12 @@
       "version": "7.3.13",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
       "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
+      "dev": true
+    },
+    "node_modules/@types/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-rFT3ak0/2trgvp4yYZo5iKFEPsET7vKydKF+VRCxlQ9bpheehyAJH89dAkaLEq/j/RZXJIqcgsmPJKUP1Z28HA==",
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -11569,10 +11586,9 @@
       "dev": true
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
       "bin": {
         "uuid": "dist/bin/uuid"
       }

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "@semantic-release/release-notes-generator": "^10.0.3",
     "@types/is-ci": "^3.0.0",
     "@types/node": "^18.14.2",
+    "@types/uuid": "^9.0.1",
     "@typescript-eslint/eslint-plugin": "^5.54.0",
     "@typescript-eslint/parser": "^5.54.0",
     "@vitest/coverage-c8": "^0.29.0",
@@ -116,6 +117,7 @@
     "@remix-run/node": "1.x"
   },
   "dependencies": {
-    "jose": "^4.13.0"
+    "jose": "^4.13.0",
+    "uuid": "^9.0.0"
   }
 }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -53,54 +53,74 @@ describe('Auth0 Remix Server', () => {
   });
 
   describe('the authorization process', () => {
-    it<LocalTestContext>('redirects to the authorization endpoint', ({ authOptions }) => {
+    it<LocalTestContext>('redirects to the authorization endpoint', async ({ authOptions }) => {
       const authorizer = new Auth0RemixServer(authOptions);
+      const request = new Request('https://it-doesnt-matter.com', {
+        method: 'POST',
+        body: new FormData()
+      });
 
-      expect(() => authorizer.authorize()).toThrowError(redirectError); // a redirect happened
+      await expect(() => authorizer.authorize(request)).rejects.toThrowError(redirectError); // a redirect happened
 
       const redirectUrl = vi.mocked(redirect).mock.calls[0][0];
       expect(redirectUrl).toMatchSnapshot();
     });
 
-    it<LocalTestContext>('forces the login if asked', ({ authOptions }) => {
+    it<LocalTestContext>('forces the login if asked', async ({ authOptions }) => {
       const authorizer = new Auth0RemixServer(authOptions);
+      const request = new Request('https://it-doesnt-matter.com', {
+        method: 'POST',
+        body: new FormData()
+      });
 
-      expect(() => authorizer.authorize({
+      await expect(() => authorizer.authorize(request, {
         forceLogin: true
-      })).toThrowError(redirectError); // a redirect happened
+      })).rejects.toThrowError(redirectError); // a redirect happened
 
       const redirectUrl = vi.mocked(redirect).mock.calls[0][0];
       expect(redirectUrl).toMatchSnapshot();
     });
 
-    it<LocalTestContext>('works correctly when both are asked', ({ authOptions }) => {
+    it<LocalTestContext>('works correctly when both are asked', async ({ authOptions }) => {
       const authorizer = new Auth0RemixServer(authOptions);
+      const request = new Request('https://it-doesnt-matter.com', {
+        method: 'POST',
+        body: new FormData()
+      });
 
-      expect(() => authorizer.authorize({
+      await expect(() => authorizer.authorize(request, {
         forceLogin: true,
         forceSignup: true
-      })).toThrowError(redirectError); // a redirect happened
+      })).rejects.toThrowError(redirectError); // a redirect happened
 
       const redirectUrl = vi.mocked(redirect).mock.calls[0][0];
       expect(redirectUrl).toMatchSnapshot();
     });
 
-    it<LocalTestContext>('forces the signup if asked', ({ authOptions }) => {
+    it<LocalTestContext>('forces the signup if asked', async ({ authOptions }) => {
       const authorizer = new Auth0RemixServer(authOptions);
+      const request = new Request('https://it-doesnt-matter.com', {
+        method: 'POST',
+        body: new FormData()
+      });
 
-      expect(() => authorizer.authorize({
+      await expect(() => authorizer.authorize(request, {
         forceSignup: true
-      })).toThrowError(redirectError); // a redirect happened
+      })).rejects.toThrowError(redirectError); // a redirect happened
 
       const redirectUrl = vi.mocked(redirect).mock.calls[0][0];
       expect(redirectUrl).toMatchSnapshot();
     });
 
-    it<LocalTestContext>('adds the organisation if needed', ({ authOptions }) => {
+    it<LocalTestContext>('adds the organisation if needed', async ({ authOptions }) => {
       authOptions.clientDetails.organization = 'test-org';
       const authorizer = new Auth0RemixServer(authOptions);
+      const request = new Request('https://it-doesnt-matter.com', {
+        method: 'POST',
+        body: new FormData()
+      });
 
-      expect(() => authorizer.authorize()).toThrowError(redirectError); // a redirect happened
+      await expect(() => authorizer.authorize(request)).rejects.toThrowError(redirectError); // a redirect happened
 
       const redirectUrl = vi.mocked(redirect).mock.calls[0][0];
       expect(redirectUrl).toMatchSnapshot();

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -20,3 +20,15 @@ export const getCredentials = async (request: Request, sessionStore: SessionStor
   const credentials = session.get(sessionStore.key);
   return credentials;
 };
+
+export const saveStateToSession = async (request: Request, state: string, sessionStorage?: SessionStore) => {
+  const headers: HeadersInit = {};
+  if (sessionStorage) {
+    const cookie = request.headers.get('Cookie');
+    const session = await sessionStorage.store.getSession(cookie);
+    session.set(sessionStorage.key, state);
+    headers['Set-Cookie'] = await sessionStorage.store.commitSession(session);
+  }
+
+  return headers;
+};


### PR DESCRIPTION
Generate the state on authorize and use it on the callback to avoid CSRF