### PR TITLE
feat: allow Auth0 prompt and connection to be set

### DIFF
--- a/src/Auth0RemixTypes.ts
+++ b/src/Auth0RemixTypes.ts
@@ -82,6 +82,8 @@ export interface Auth0RemixOptions {
 export interface AuthorizeOptions {
   forceLogin?: boolean;
   forceSignup?: boolean;
+  prompt?: string;
+  connection?: string;
 }
 
 export interface HandleCallbackOptions {

--- a/src/__snapshots__/index.test.ts.snap
+++ b/src/__snapshots__/index.test.ts.snap
@@ -20,6 +20,10 @@ exports[`Auth0 Remix Server > the authorization process > forces the login if as
 
 exports[`Auth0 Remix Server > the authorization process > forces the signup if asked 1`] = `"https://test.domain.com/authorize?response_type=code&response_mode=form_post&client_id=clientId&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fauth0%2Fcallback&scope=offline_access+openid+profile+email&audience=https%3A%2F%2Ftest.domain.com%2Fapi%2Fv2%2F&screen_hint=signup"`;
 
+exports[`Auth0 Remix Server > the authorization process > includes the connection 1`] = `"https://test.domain.com/authorize?response_type=code&response_mode=form_post&client_id=clientId&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fauth0%2Fcallback&scope=offline_access+openid+profile+email&audience=https%3A%2F%2Ftest.domain.com%2Fapi%2Fv2%2F&connection=google"`;
+
+exports[`Auth0 Remix Server > the authorization process > includes the prompt type 1`] = `"https://test.domain.com/authorize?response_type=code&response_mode=form_post&client_id=clientId&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fauth0%2Fcallback&scope=offline_access+openid+profile+email&audience=https%3A%2F%2Ftest.domain.com%2Fapi%2Fv2%2F&prompt=none"`;
+
 exports[`Auth0 Remix Server > the authorization process > redirects to the authorization endpoint 1`] = `"https://test.domain.com/authorize?response_type=code&response_mode=form_post&client_id=clientId&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fauth0%2Fcallback&scope=offline_access+openid+profile+email&audience=https%3A%2F%2Ftest.domain.com%2Fapi%2Fv2%2F"`;
 
 exports[`Auth0 Remix Server > the authorization process > works correctly when both are asked 1`] = `"https://test.domain.com/authorize?response_type=code&response_mode=form_post&client_id=clientId&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fauth0%2Fcallback&scope=offline_access+openid+profile+email&audience=https%3A%2F%2Ftest.domain.com%2Fapi%2Fv2%2F&prompt=login&screen_hint=signup"`;

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -67,9 +67,37 @@ describe('Auth0 Remix Server', () => {
     it<LocalTestContext>('forces the login if asked', ({ authOptions }) => {
       const authorizer = new Auth0RemixServer(authOptions);
 
-      expect(() => authorizer.authorize({
-        forceLogin: true
-      })).toThrowError(redirectError); // a redirect happened
+      expect(() =>
+        authorizer.authorize({
+          forceLogin: true
+        })
+      ).toThrowError(redirectError); // a redirect happened
+
+      const redirectUrl = vi.mocked(redirect).mock.calls[0][0];
+      expect(redirectUrl).toMatchSnapshot();
+    });
+
+    it<LocalTestContext>('includes the connection', ({ authOptions }) => {
+      const authorizer = new Auth0RemixServer(authOptions);
+
+      expect(() =>
+        authorizer.authorize({
+          connection: 'google'
+        })
+      ).toThrowError(redirectError); // a redirect happened
+
+      const redirectUrl = vi.mocked(redirect).mock.calls[0][0];
+      expect(redirectUrl).toMatchSnapshot();
+    });
+
+    it<LocalTestContext>('includes the prompt type', ({ authOptions }) => {
+      const authorizer = new Auth0RemixServer(authOptions);
+
+      expect(() =>
+        authorizer.authorize({
+          prompt: 'none'
+        })
+      ).toThrowError(redirectError); // a redirect happened
 
       const redirectUrl = vi.mocked(redirect).mock.calls[0][0];
       expect(redirectUrl).toMatchSnapshot();

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,12 @@ import type {
 } from './Auth0RemixTypes.js';
 import type { AppLoadContext } from '@remix-run/server-runtime';
 
+export * from './Auth0RemixTypes.js';
+
+// This is just an export; it does not need to be tested
+/* c8 ignore next */
+export const TokenErrorInstance = jose.errors.JOSEError;
+
 export enum Token {
   ID = 'id',
   ACCESS = 'access'
@@ -120,6 +126,12 @@ export class Auth0RemixServer {
     authorizationURL.searchParams.set('audience', this.clientCredentials.audience);
     if (this.clientCredentials.organization) {
       authorizationURL.searchParams.set('organization', this.clientCredentials.organization);
+    }
+    if (opts.connection) {
+      authorizationURL.searchParams.set('connection', opts.connection);
+    }
+    if (opts.prompt) {
+      authorizationURL.searchParams.set('prompt', opts.prompt);
     }
     if (opts.forceLogin) {
       authorizationURL.searchParams.set('prompt', 'login');


### PR DESCRIPTION
Part 1 of #138 , exposing `prompt` and `connection` on the `AuthorizeOptions` interface.

This also export the types (which may be unnecessary, happy to discuss and revery if necessary) and the `TokenErrorInstance` class alias.