### PR TITLE
feat: allow overriding failure redirect

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "npmignore": "0.3.0",
         "publint": "0.1.12",
         "rimraf": "5.0.1",
-        "semantic-release": "21.0.5",
+        "semantic-release": "21.0.6",
         "semantic-release-export-data": "1.0.1",
         "type-fest": "3.12.0",
         "typescript": "5.1.5",
@@ -10796,9 +10796,9 @@
       "dev": true
     },
     "node_modules/semantic-release": {
-      "version": "21.0.5",
-      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-21.0.5.tgz",
-      "integrity": "sha512-mCc7Hx9Ro/1Clk9tLLgwQIQuiEzx+1OX12EazvNysnx1VG4eaNJE9b9IyWtTxyFxaFYi7nM5VB5ZDVzheHTDPA==",
+      "version": "21.0.6",
+      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-21.0.6.tgz",
+      "integrity": "sha512-NDyosObAwUNzPpdf+mpL49Xy+5iYHjdWM34LBNdbdYv9vBLbw+eCCDihxcqPh+f9m4ZzlBrYCkHUaZv2vPGW9A==",
       "dev": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^10.0.0",
@@ -10974,9 +10974,9 @@
       }
     },
     "node_modules/semantic-release/node_modules/marked": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-5.0.5.tgz",
-      "integrity": "sha512-auTmKJTBwZM/GLVFOhmkY7pL8v/0DxiDaXRC2kEyajcNJ0XXn9NphLD0106dbWrbPwcyD4Y0Dus16OkCzUMkfg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-5.1.0.tgz",
+      "integrity": "sha512-z3/nBe7aTI8JDszlYLk7dDVNpngjw0o1ZJtrA9kIfkkHcIF+xH7mO23aISl4WxP83elU+MFROgahqdpd05lMEQ==",
       "dev": true,
       "bin": {
         "marked": "bin/marked.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "semantic-release": "21.0.6",
         "semantic-release-export-data": "1.0.1",
         "type-fest": "3.12.0",
-        "typescript": "5.1.5",
+        "typescript": "5.1.6",
         "vite": "4.3.9",
         "vitest": "0.31.4"
       },
@@ -12032,9 +12032,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.5.tgz",
-      "integrity": "sha512-FOH+WN/DQjUvN6WgW+c4Ml3yi0PH+a/8q+kNIfRehv1wLhWONedw85iu+vQ39Wp49IzTJEsZ2lyLXpBF7mkF1g==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "npmignore": "0.3.0",
     "publint": "0.1.12",
     "rimraf": "5.0.1",
-    "semantic-release": "21.0.5",
+    "semantic-release": "21.0.6",
     "semantic-release-export-data": "1.0.1",
     "type-fest": "3.12.0",
     "typescript": "5.1.5",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "semantic-release": "21.0.6",
     "semantic-release-export-data": "1.0.1",
     "type-fest": "3.12.0",
-    "typescript": "5.1.5",
+    "typescript": "5.1.6",
     "vite": "4.3.9",
     "vitest": "0.31.4"
   },

--- a/src/Auth0RemixTypes.ts
+++ b/src/Auth0RemixTypes.ts
@@ -86,4 +86,5 @@ export interface AuthorizeOptions {
 
 export interface HandleCallbackOptions {
   onSuccessRedirect?: string;
+  onFailedRedirect?: string;
 }

--- a/src/__snapshots__/index.test.ts.snap
+++ b/src/__snapshots__/index.test.ts.snap
@@ -1,5 +1,25 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`Auth0 Remix Server > handling the callback token exchange > when there is a code in the exchange > and no error body is returned > redirects with a generic error param value 2`] = `
+{
+  "body": "grant_type=authorization_code&client_id=clientId&client_secret=clientSecret&code=test-code&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fauth0%2Fcallback",
+  "headers": {
+    "content-type": "application/x-www-form-urlencoded",
+  },
+  "method": "POST",
+}
+`;
+
+exports[`Auth0 Remix Server > handling the callback token exchange > when there is a code in the exchange > and the failedLoginRedirect contains a query string parameter > redirects with a well-formed path containing the error parameter 2`] = `
+{
+  "body": "grant_type=authorization_code&client_id=clientId&client_secret=clientSecret&code=test-code&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fauth0%2Fcallback",
+  "headers": {
+    "content-type": "application/x-www-form-urlencoded",
+  },
+  "method": "POST",
+}
+`;
+
 exports[`Auth0 Remix Server > handling the callback token exchange > when there is a code in the exchange > redirects to the failed login url if the token exchange fails 2`] = `
 {
   "body": "grant_type=authorization_code&client_id=clientId&client_secret=clientSecret&code=test-code&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fauth0%2Fcallback",

--- a/src/index.ts
+++ b/src/index.ts
@@ -285,7 +285,8 @@ export class Auth0RemixServer {
     let error = 'no_response';
     if (response.body) {
       const data = await response.json();
-      if (data.error) {
+
+      if (data && typeof data === 'object' && 'error' in data && data.error && typeof data.error === 'string') {
         error = data.error;
       }
     }


### PR DESCRIPTION
This is part 2 of #138 - allowing `failedRedirectUrl` to be overridden through the `HandleCallbackOptions` interface.

I struggled a bit to obey the test and commit rules but got there eventually, I think. It looks like VS Code has mangled style rules - any pointers for how to get them clean for this repo's expectations would be appreciated.