### PR TITLE
feat: allow extra callback query string params

### DIFF
--- a/src/Auth0RemixTypes.ts
+++ b/src/Auth0RemixTypes.ts
@@ -69,6 +69,7 @@ export interface Auth0RemixOptions {
 }
 
 export interface AuthorizeOptions {
+  callbackParams?: Record<string, string>;
   forceLogin?: boolean;
   forceSignup?: boolean;
 }

--- a/src/__snapshots__/index.test.ts.snap
+++ b/src/__snapshots__/index.test.ts.snap
@@ -14,6 +14,8 @@ exports[`Auth0 Remix Server > logging out > calls the correct url 1`] = `"https:
 
 exports[`Auth0 Remix Server > logging out > includes the headers supplied 1`] = `"https://test.domain.com/v2/logout?client_id=clientId&returnTo=http%3A%2F%2Flocalhost%3A3000%2Flogout-with-headers"`;
 
+exports[`Auth0 Remix Server > the authorization process > adds extra callback parameters when given 1`] = `"https://test.domain.com/authorize?response_type=code&response_mode=form_post&client_id=clientId&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fauth0%2Fcallback%3Fcode%3Dasdfghkl%26state%3D1234qwer&scope=offline_access+openid+profile+email&audience=https%3A%2F%2Ftest.domain.com%2Fapi%2Fv2%2F"`;
+
 exports[`Auth0 Remix Server > the authorization process > adds the organisation if needed 1`] = `"https://test.domain.com/authorize?response_type=code&response_mode=form_post&client_id=clientId&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fauth0%2Fcallback&scope=offline_access+openid+profile+email&audience=https%3A%2F%2Ftest.domain.com%2Fapi%2Fv2%2F&organization=test-org"`;
 
 exports[`Auth0 Remix Server > the authorization process > forces the login if asked 1`] = `"https://test.domain.com/authorize?response_type=code&response_mode=form_post&client_id=clientId&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fauth0%2Fcallback&scope=offline_access+openid+profile+email&audience=https%3A%2F%2Ftest.domain.com%2Fapi%2Fv2%2F&prompt=login"`;

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -65,9 +65,27 @@ describe('Auth0 Remix Server', () => {
     it<LocalTestContext>('forces the login if asked', ({ authOptions }) => {
       const authorizer = new Auth0RemixServer(authOptions);
 
-      expect(() => authorizer.authorize({
-        forceLogin: true
-      })).toThrowError(redirectError); // a redirect happened
+      expect(() =>
+        authorizer.authorize({
+          forceLogin: true
+        })
+      ).toThrowError(redirectError); // a redirect happened
+
+      const redirectUrl = vi.mocked(redirect).mock.calls[0][0];
+      expect(redirectUrl).toMatchSnapshot();
+    });
+
+    it<LocalTestContext>('adds extra callback parameters when given', ({ authOptions }) => {
+      const authorizer = new Auth0RemixServer(authOptions);
+
+      expect(() =>
+        authorizer.authorize({
+          callbackParams: {
+            code: 'asdfghkl',
+            state: '1234qwer'
+          }
+        })
+      ).toThrowError(redirectError); // a redirect happened
 
       const redirectUrl = vi.mocked(redirect).mock.calls[0][0];
       expect(redirectUrl).toMatchSnapshot();

--- a/src/index.ts
+++ b/src/index.ts
@@ -106,10 +106,13 @@ export class Auth0RemixServer {
       'profile',
       'email'];
     const authorizationURL = new URL(this.auth0Urls.authorizationURL);
+
+    const callbackURL = opts.callbackParams ? this.addExtraCallbackParams(opts.callbackParams) : this.callbackURL;
+
     authorizationURL.searchParams.set('response_type', 'code');
     authorizationURL.searchParams.set('response_mode', 'form_post');
     authorizationURL.searchParams.set('client_id', this.clientCredentials.clientID);
-    authorizationURL.searchParams.set('redirect_uri', this.callbackURL);
+    authorizationURL.searchParams.set('redirect_uri', callbackURL);
     authorizationURL.searchParams.set('scope', scope.join(' '));
     authorizationURL.searchParams.set('audience', this.clientCredentials.audience);
     if (this.clientCredentials.organization) {
@@ -272,5 +275,20 @@ export class Auth0RemixServer {
 
     const data = await response.json();
     return transformUserData(data);
+  }
+
+  private addExtraCallbackParams(extraParams: Record<string, string>) {
+    let callbackURL = this.callbackURL;
+
+    if (extraParams) {
+      const withExtraParams = new URL(callbackURL);
+      console.log(`Adding callback params ${JSON.stringify(extraParams)}`);
+      for (const [key, value] of Object.entries(extraParams)) {
+        withExtraParams.searchParams.set(key, value);
+      }
+      callbackURL = withExtraParams.toString();
+    }
+
+    return callbackURL;
   }
 }


### PR DESCRIPTION
Part 3 of #138 - this allows extra parameters to be specified when calling `authorize` so that they are added to the callback URI, which will allow those to be passed downstream in the auth flow.