### PR TITLE
ci: use built-in token for releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ env:
   LEFTHOOK: 0
 
 permissions:
-  issues: read
+  issues: write
   checks: write
   contents: write
   pull-requests: write
@@ -15,7 +15,7 @@ jobs:
   verify:
     uses: meza/shared-github-workflows/.github/workflows/default-node-npm-ci.yml@main
     secrets:
-      GH_TOKEN: ${{ secrets.GH_TOKEN }}
+      GH_TOKEN: ${{ github.token }}
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
     with:
       node-version: "latest"
@@ -40,6 +40,6 @@ jobs:
       - name: 🚀 Release
         if: needs.verify.outputs.new-release-published == 'true'
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm run release


### PR DESCRIPTION
## Summary

- replace the long-lived release PAT with the repository-scoped GitHub token
- preserve existing workflow permissions and grant only missing semantic-release permissions

## Validation

- parsed the updated workflow as YAML
- verified no `secrets.GH_TOKEN` reference remains in the edited workflow