### PR TITLE
ci: use self-hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       junit-report-path: "reports/junit.xml"
       cobertura-report-path: "reports/**/cobertura-coverage.xml"
   build:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     needs: [ verify ]
     name: Build
     steps:


### PR DESCRIPTION
Replace compatible GitHub-hosted runner selections with the self-hosted runner.