### PR TITLE
chore(ci): use meza ubuntu slim runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       junit-report-path: "reports/junit.xml"
       cobertura-report-path: "reports/**/cobertura-coverage.xml"
   build:
-    runs-on: self-hosted
+    runs-on: meza-ubuntu-slim
     needs: [ verify ]
     name: Build
     steps:


### PR DESCRIPTION
## Summary

Replace `runs-on: self-hosted` with `runs-on: meza-ubuntu-slim` in 1 GitHub Actions workflow file.

## Validation

- Verified 1 exact runner-label replacement.
- Verified no other staged lines changed.
- `git diff --check` passes.